### PR TITLE
Check if Chart defined before displaying Tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Add default Color Mode Id for older releases (7.2.X) #49
 - Fix Latency below zero calculation #56
+- "Cannot read property 'Tooltip' of undefined" for Latency Panel in the upcoming release #60
 
 ## v1.1.0 (2021-02-07)
 

--- a/src/redis-gears-panel/components/code-editor/code-editor.test.tsx
+++ b/src/redis-gears-panel/components/code-editor/code-editor.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { shallow } from 'enzyme';
+import React from 'react';
 import Editor from '@monaco-editor/react';
 import { UnthemedCodeEditor } from './code-editor';
 

--- a/src/redis-latency-panel/components/redis-latency-panel-graph/redis-latency-panel-graph.tsx
+++ b/src/redis-latency-panel/components/redis-latency-panel-graph/redis-latency-panel-graph.tsx
@@ -13,7 +13,7 @@ import {
   TimeZone,
   toDataFrame,
 } from '@grafana/data';
-import { Chart, colors, GraphWithLegend, LegendDisplayMode } from '@grafana/ui';
+import { Chart, colors, GraphWithLegend, LegendDisplayMode, Tooltip, TooltipPlugin } from '@grafana/ui';
 import { DefaultColorModeId } from '../../constants';
 import { PanelOptions, SeriesMap, SeriesValue } from '../../types';
 
@@ -210,7 +210,7 @@ export class RedisLatencyPanelGraph extends PureComponent<Props, State> {
         hideZero={options?.hideZero}
         showLines
       >
-        <Chart.Tooltip mode="multi"></Chart.Tooltip>
+        {Chart && <Chart.Tooltip mode="multi"></Chart.Tooltip>}
       </GraphWithLegend>
     );
   }

--- a/src/redis-latency-panel/components/redis-latency-panel-graph/redis-latency-panel-graph.tsx
+++ b/src/redis-latency-panel/components/redis-latency-panel-graph/redis-latency-panel-graph.tsx
@@ -13,7 +13,7 @@ import {
   TimeZone,
   toDataFrame,
 } from '@grafana/data';
-import { Chart, colors, GraphWithLegend, LegendDisplayMode, Tooltip, TooltipPlugin } from '@grafana/ui';
+import { Chart, colors, GraphWithLegend, LegendDisplayMode } from '@grafana/ui';
 import { DefaultColorModeId } from '../../constants';
 import { PanelOptions, SeriesMap, SeriesValue } from '../../types';
 


### PR DESCRIPTION
Fixes #61.

Unfortunately, until #62 will be done Tooltip is not displayed for the upcoming Grafana 8.